### PR TITLE
add cas arg to git-xet mount

### DIFF
--- a/rust/k8s-csi-xetfs/src/driver/mount.rs
+++ b/rust/k8s-csi-xetfs/src/driver/mount.rs
@@ -36,13 +36,14 @@ impl Mounter for GitXetMounter {
         ];
         info!("mount, running {GIT_XET_BIN} with args: {args:?}");
         cmd.args(args);
+        cmd.env("XET_LOG_LEVEL", "info");
         if !volume_spec.user.is_empty() && !volume_spec.pat.is_empty() {
             info!("setting user name and token env vars in mount command");
-            cmd.envs([
-                ("XET_LOG_LEVEL", "info"),
-                (GIT_XET_ENV_VAR_USER_NAME, volume_spec.user.as_str()),
-                (GIT_XET_ENV_VAR_USER_TOKEN, volume_spec.pat.as_str()),
-            ]);
+            cmd.env(GIT_XET_ENV_VAR_USER_NAME, volume_spec.user.as_str());
+            cmd.env(GIT_XET_ENV_VAR_USER_TOKEN, volume_spec.pat.as_str());
+        }
+        if let Some(cas) = &volume_spec.cas {
+            cmd.env("XET_CAS_SERVER", cas.as_str());
         }
 
         cmd.spawn()?.wait().await?;

--- a/rust/k8s-csi-xetfs/src/driver/volume.rs
+++ b/rust/k8s-csi-xetfs/src/driver/volume.rs
@@ -13,10 +13,12 @@ pub(crate) struct XetCSIVolume {
     pub(crate) user: String,
     #[redact]
     pub(crate) pat: String,
+    pub(crate) cas: Option<String>,
 }
 
 const VOLUME_CONTEXT_REPO_KEY: &str = "repo";
 const VOLUME_CONTEXT_COMMIT_KEY: &str = "commit";
+const VOLUME_CONTEXT_CAS_KEY: &str = "cas";
 const SECRETS_USER_KEY: &str = "user";
 const SECRETS_PAT_KEY: &str = "pat";
 
@@ -44,6 +46,9 @@ impl TryFrom<NodePublishVolumeRequest> for XetCSIVolume {
         let user = value.secrets.remove(SECRETS_USER_KEY).unwrap_or_default();
         let pat = value.secrets.remove(SECRETS_PAT_KEY).unwrap_or_default();
 
+        // cas is optional and stored as option
+        let cas = value.volume_context.remove(VOLUME_CONTEXT_CAS_KEY);
+
         Ok(XetCSIVolume {
             volume_id: value.volume_id,
             path: value.target_path,
@@ -51,6 +56,7 @@ impl TryFrom<NodePublishVolumeRequest> for XetCSIVolume {
             commit,
             user,
             pat,
+            cas,
         })
     }
 }


### PR DESCRIPTION
Add the cas argument to the volume spec to git-xet mount to specify the cas server. Much like the changes we needed in the docker volume plugin.